### PR TITLE
Be/refresh token

### DIFF
--- a/Sumo/build.gradle
+++ b/Sumo/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.codestates'
-version = '0.3.2-SNAPSHOT'
+version = '0.3.0-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {

--- a/Sumo/build.gradle
+++ b/Sumo/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.codestates'
-version = '0.2.2-SNAPSHOT'
+version = '0.3.2-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {

--- a/Sumo/src/main/java/com/codestates/jwt/auth/filter/JwtVerificationFilter.java
+++ b/Sumo/src/main/java/com/codestates/jwt/auth/filter/JwtVerificationFilter.java
@@ -1,9 +1,17 @@
 package com.codestates.jwt.auth.filter;
 
+import com.codestates.exception.BusinessLogicException;
+import com.codestates.exception.ExceptionCode;
 import com.codestates.jwt.JwtTokenizer;
 import com.codestates.jwt.auth.utils.CustomAuthorityUtils;
+import com.codestates.jwt.auth.utils.JwtDecoder;
+import com.codestates.jwt.auth.utils.tokenWithExpiration;
+import com.codestates.member.entity.Member;
+import com.codestates.member.repository.MemberRepository;
+import com.codestates.response.ErrorResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -15,32 +23,48 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
+import java.time.Instant;
+import java.util.*;
 
+@Slf4j
 public class JwtVerificationFilter extends OncePerRequestFilter {
     private final JwtTokenizer jwtTokenizer;
     private final CustomAuthorityUtils authorityUtils;
+    private final JwtDecoder jwtDecoder;
 
+    private final MemberRepository memberRepository;
 
-    public JwtVerificationFilter(JwtTokenizer jwtTokenizer,
-                                 CustomAuthorityUtils authorityUtils) {
+    public JwtVerificationFilter(JwtTokenizer jwtTokenizer, CustomAuthorityUtils authorityUtils, JwtDecoder jwtDecoder, MemberRepository memberRepository) {
         this.jwtTokenizer = jwtTokenizer;
         this.authorityUtils = authorityUtils;
+        this.jwtDecoder = jwtDecoder;
+        this.memberRepository = memberRepository;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             Map<String, Object> claims = verifyJws(request);
+            if((Integer)claims.get("exp") - Instant.now().getEpochSecond() <= 0){
+                regenerateAuthenticationToken(claims, response);
+            }
             setAuthenticationToContext(claims);
         } catch (SignatureException se) {
             request.setAttribute("exception", se);
         } catch (ExpiredJwtException ee) {
             request.setAttribute("exception", ee);
+            try {
+                verifyRefresh(request);
+                Map<String, Object> claimsAuth = jwtDecoder.decode(request);
+                setAuthenticationToContext(claimsAuth);
+                regenerateAuthenticationToken(claimsAuth, response);
+            } catch (Exception e) {
+                request.setAttribute("exception", e);
+            }
         } catch (Exception e) {
             request.setAttribute("exception", e);
         }
+        log.debug("# passed");
         filterChain.doFilter(request, response);
     }
 
@@ -60,10 +84,42 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
         return claims;
     }
 
+    private void verifyRefresh(HttpServletRequest request) {
+        String jws = request.getHeader("Refresh");
+        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+        jwtTokenizer.verifySignature(jws, base64EncodedSecretKey);
+    }
+
     private void setAuthenticationToContext(Map<String, Object> claims) {
         String username = (String) claims.get("username");   // (4-1)
         List<GrantedAuthority> authorities = authorityUtils.createAuthorities((List)claims.get("roles"));
         Authentication authentication = new UsernamePasswordAuthenticationToken(username, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private void regenerateAuthenticationToken(Map<String, Object> claims, HttpServletResponse response) {
+        Optional<Member> memberOptional = memberRepository.findByEmail((String)claims.get("sub"));
+        Member member = memberOptional.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+
+        tokenWithExpiration access = delegateAccessToken(member);
+        String accessToken = access.getToken();
+
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.addHeader("AuthExpiration",access.getDate().toString());
+    }
+
+    private tokenWithExpiration delegateAccessToken(Member member) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("username", member.getEmail());
+        claims.put("roles", member.getRoles());
+
+        String subject = member.getEmail();
+        Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getAccessTokenExpirationMinutes());
+
+        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+
+        String accessToken = jwtTokenizer.generateAccessToken(claims, subject, expiration, base64EncodedSecretKey);
+
+        return new tokenWithExpiration(accessToken,expiration);
     }
 }

--- a/Sumo/src/main/java/com/codestates/jwt/auth/utils/JwtDecoder.java
+++ b/Sumo/src/main/java/com/codestates/jwt/auth/utils/JwtDecoder.java
@@ -1,0 +1,35 @@
+package com.codestates.jwt.auth.utils;
+
+import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class JwtDecoder {
+    public Map<String, Object> decode(HttpServletRequest request){
+        String jws = request.getHeader("Authorization").replace("Bearer ", "");
+        String[] jwtParts = jws.split("\\.");
+        String base64EncodedClaims = jwtParts[1];
+        byte[] decodedBytes = Base64.getUrlDecoder().decode(base64EncodedClaims);
+        String claimsJson = new String(decodedBytes, StandardCharsets.UTF_8);
+
+        Gson gson = new Gson();
+        Map<String, Object> claims = gson.fromJson(claimsJson, Map.class);
+
+        log.debug("Jwt decode complete");
+
+        StringBuilder result = new StringBuilder();
+        for (Map.Entry<String, Object> entry : claims.entrySet()) {
+            result.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+        }
+        log.debug(result.toString());
+
+        return claims;
+    }
+}

--- a/Sumo/src/main/java/com/codestates/jwt/auth/utils/tokenWithExpiration.java
+++ b/Sumo/src/main/java/com/codestates/jwt/auth/utils/tokenWithExpiration.java
@@ -1,0 +1,13 @@
+package com.codestates.jwt.auth.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+public class tokenWithExpiration {
+    private String token;
+    private Date date;
+}

--- a/Sumo/src/main/java/com/codestates/jwt/config/SecurityConfiguration.java
+++ b/Sumo/src/main/java/com/codestates/jwt/config/SecurityConfiguration.java
@@ -8,6 +8,8 @@ import com.codestates.jwt.auth.handler.MemberAuthenticationEntryPoint;
 import com.codestates.jwt.auth.handler.MemberAuthenticationFailureHandler;
 import com.codestates.jwt.auth.handler.MemberAuthenticationSuccessHandler;
 import com.codestates.jwt.auth.utils.CustomAuthorityUtils;
+import com.codestates.jwt.auth.utils.JwtDecoder;
+import com.codestates.member.repository.MemberRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -30,11 +32,15 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfiguration{
     private final JwtTokenizer jwtTokenizer;
     private final CustomAuthorityUtils authorityUtils;
+    private final JwtDecoder jwtDecoder;
 
-    public SecurityConfiguration(JwtTokenizer jwtTokenizer,
-                                 CustomAuthorityUtils authorityUtils) {
+    private final MemberRepository memberRepository;
+
+    public SecurityConfiguration(JwtTokenizer jwtTokenizer, CustomAuthorityUtils authorityUtils, JwtDecoder jwtDecoder, MemberRepository memberRepository) {
         this.jwtTokenizer = jwtTokenizer;
         this.authorityUtils = authorityUtils;
+        this.jwtDecoder = jwtDecoder;
+        this.memberRepository = memberRepository;
     }
 
     @Bean
@@ -104,7 +110,7 @@ public class SecurityConfiguration{
             jwtAuthenticationFilter.setAuthenticationSuccessHandler(new MemberAuthenticationSuccessHandler());
             jwtAuthenticationFilter.setAuthenticationFailureHandler(new MemberAuthenticationFailureHandler());
 
-            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils);
+            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils, jwtDecoder,memberRepository);
 
             builder.addFilter(jwtAuthenticationFilter)
                     .addFilterAfter(jwtVerificationFilter, JwtAuthenticationFilter.class);


### PR DESCRIPTION
만료된 authentication token과 refresh token을 같이 받는다.
만약 같이 받았을 때
1. refresh token이 유효할 때 : 새롭게 authentication token을 발행한다.
2. refresh token이 비정상적인 토큰일 때 : 에러를 뱉는다.

개선 가능(기능을 추가할 수는 있으나, 시간 관계 상 안될 것 같은 기능)
refresh token을 db에 따로 저장해 해커가 refresh token을 탈취했을 때,
authentication token을 무제한 발행할 수 있는 점을 방지할 수 있다.